### PR TITLE
test(math): remove Math.random() and make assertions deterministic

### DIFF
--- a/src/math.test.ts
+++ b/src/math.test.ts
@@ -5,17 +5,17 @@ Array(5)
   .fill(0)
   .forEach((_, index) => {
     it(`adds ${index} + 2 to equal ${index + 2}`, () => {
-      const isFlaky = Math.random() > 0.5;
-      expect(sum(index, 2)).toBe(isFlaky ? 100 : index + 2);
+      
+      expect(sum(index, 2)).toBe(index + 2);
     });
   });
 
 it("adds 2 + 5 to equal 7", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 5)).toBe(isFlaky ? 100 : 7);
+  
+  expect(sum(2, 5)).toBe(7);
 });
 
 it("adds 2 + 6 to equal 8", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 6)).toBe(isFlaky ? 100 : 8);
+  
+  expect(sum(2, 6)).toBe(8);
 });


### PR DESCRIPTION
- **Root cause:** Tests introduced nondeterminism by using Math.random() to alter expected values (e.g., isFlaky ? 100 : expected), making src/math.test.ts.adds 2 + 5 to equal 7 flaky.
- **Proposed fix:** Remove Math.random() from all math tests (including looped cases and "adds 2 + 6 to equal 8") and assert deterministically (e.g., expect(sum(2, 5)).toBe(7); loop: expect(sum(i, 2)).toBe(i + 2)). If randomness must be covered, mock it deterministically via vi.spyOn(Math, 'random').mockReturnValue(0).
- **Verification:** **Verification:** 10/10 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/baafd8a3-f296-447b-8918-d34ff264afce)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)