### PR TITLE
test(math): deflake src/math.test.ts by removing randomness

### DIFF
--- a/src/math.test.ts
+++ b/src/math.test.ts
@@ -1,21 +1,20 @@
 import { expect, it } from "vitest";
 import { sum } from "./math";
 
-Array(5)
-  .fill(0)
-  .forEach((_, index) => {
-    it(`adds ${index} + 2 to equal ${index + 2}`, () => {
-      const isFlaky = Math.random() > 0.5;
-      expect(sum(index, 2)).toBe(isFlaky ? 100 : index + 2);
-    });
-  });
+it.each([
+  [0, 2, 2],
+  [1, 2, 3],
+  [2, 2, 4],
+  [3, 2, 5],
+  [4, 2, 6],
+])("adds %d + %d to equal %d", (a, b, expected) => {
+  expect(sum(a, b)).toBe(expected);
+});
 
 it("adds 2 + 5 to equal 7", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 5)).toBe(isFlaky ? 100 : 7);
+  expect(sum(2, 5)).toBe(7);
 });
 
 it("adds 2 + 6 to equal 8", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 6)).toBe(isFlaky ? 100 : 8);
+  expect(sum(2, 6)).toBe(8);
 });


### PR DESCRIPTION
- **Root cause:** Randomized assertions via `isFlaky` (`Math.random()`) made tests nondeterministic across table and individual cases, causing flakes in src/math.test.ts.adds 2 + 5 to equal 7.
- **Proposed fix:** Remove `isFlaky` and all `Math.random()` usage; make expectations deterministic (`expect(sum(index, 2)).toBe(index + 2)`, `expect(sum(2, 5)).toBe(7)`, `expect(sum(2, 6)).toBe(8)`); refactor to `it.each` for clarity and stability; if randomness is required, stub it with `vi.spyOn(Math, 'random').mockReturnValue(0)`.
- **Verification:** **Verification:** 10/10 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/baafd8a3-f296-447b-8918-d34ff264afce)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)