### PR TITLE
test(math): remove randomness; refactor to table-driven cases

### DIFF
--- a/src/math.test.ts
+++ b/src/math.test.ts
@@ -1,21 +1,20 @@
 import { expect, it } from "vitest";
 import { sum } from "./math";
 
-Array(5)
-  .fill(0)
-  .forEach((_, index) => {
-    it(`adds ${index} + 2 to equal ${index + 2}`, () => {
-      const isFlaky = Math.random() > 0.5;
-      expect(sum(index, 2)).toBe(isFlaky ? 100 : index + 2);
-    });
-  });
+it.each([
+  [0, 2, 2],
+  [1, 2, 3],
+  [2, 2, 4],
+  [3, 2, 5],
+  [4, 2, 6],
+])("adds %d + %d = %d", (a, b, expected) => {
+  expect(sum(a, b)).toBe(expected);
+});
 
 it("adds 2 + 5 to equal 7", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 5)).toBe(isFlaky ? 100 : 7);
+  expect(sum(2, 5)).toBe(7);
 });
 
 it("adds 2 + 6 to equal 8", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 6)).toBe(isFlaky ? 100 : 8);
+  expect(sum(2, 6)).toBe(8);
 });


### PR DESCRIPTION
- **Root cause:** src/math.test.ts.adds 2 + 5 to equal 7 flaked because the test used `Math.random()` to sometimes assert `100` instead of the actual sum, producing a 50% failure rate unrelated to deterministic `sum(a,b)` in `src/math.ts`.
- **Proposed fix:** Removed `isFlaky`/`Math.random()`; made expectations deterministic; refactored to table-driven `it.each` cases; recommend stubbing `Math.random` via `vi.spyOn` when randomness is required and adding a lint/review rule to forbid `Math.random()` in tests.
- **Verification:** **Verification:** 10/10 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/baafd8a3-f296-447b-8918-d34ff264afce)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)