### PR TITLE
test: deflake sum tests by removing Math.random usage

### DIFF
--- a/src/math.test.ts
+++ b/src/math.test.ts
@@ -1,21 +1,16 @@
-import { expect, it } from "vitest";
+import { expect, it, describe } from "vitest";
 import { sum } from "./math";
 
-Array(5)
-  .fill(0)
-  .forEach((_, index) => {
-    it(`adds ${index} + 2 to equal ${index + 2}`, () => {
-      const isFlaky = Math.random() > 0.5;
-      expect(sum(index, 2)).toBe(isFlaky ? 100 : index + 2);
-    });
+describe("sum", () => {
+  it.each([
+    [0, 2, 2],
+    [1, 2, 3],
+    [2, 2, 4],
+    [3, 2, 5],
+    [4, 2, 6],
+    [2, 5, 7],
+    [2, 6, 8],
+  ])("adds %d + %d = %d", (a, b, expected) => {
+    expect(sum(a, b)).toBe(expected);
   });
-
-it("adds 2 + 5 to equal 7", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 5)).toBe(isFlaky ? 100 : 7);
-});
-
-it("adds 2 + 6 to equal 8", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 6)).toBe(isFlaky ? 100 : 8);
 });


### PR DESCRIPTION
- **Root cause:** Flaky test `src/math.test.ts.adds 2 + 5 to equal 7` used `Math.random()` to toggle expectations, making assertions nondeterministic while `sum` is deterministic.
- **Proposed fix:** Remove randomness and assert deterministic outcomes via table-driven tests (`it.each`). If randomness must be exercised, stub with `vi.spyOn(Math, 'random').mockReturnValue(0)` and restore.
- **Verification:** **Verification:** 10/10 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/baafd8a3-f296-447b-8918-d34ff264afce)



## Agent Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)