### PR TITLE
test(math): remove randomness; parametrize deterministic cases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,14 @@ jobs:
           paths:
             - node_modules
       - run:
-          name: Run tests with JUnit reporter
+          name: Guardrail: forbid Math.random in tests
+          command: |
+            if grep -R --include=*.test.* -n "Math\\.random(" src; then
+              echo "Found forbidden Math.random() calls in tests. Use mocking instead.";
+              exit 1;
+            fi
+      - run:
+          name: Run tests
           command: |
             npm run test
       - store_test_results:

--- a/src/math.test.ts
+++ b/src/math.test.ts
@@ -1,21 +1,22 @@
-import { expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { sum } from "./math";
 
-Array(5)
-  .fill(0)
-  .forEach((_, index) => {
-    it(`adds ${index} + 2 to equal ${index + 2}`, () => {
-      const isFlaky = Math.random() > 0.5;
-      expect(sum(index, 2)).toBe(isFlaky ? 100 : index + 2);
-    });
+describe("sum", () => {
+  it.each([
+    [0, 2, 2],
+    [1, 2, 3],
+    [2, 2, 4],
+    [3, 2, 5],
+    [4, 2, 6],
+  ])("adds %d + %d to equal %d", (a, b, expected) => {
+    expect(sum(a, b)).toBe(expected);
   });
 
-it("adds 2 + 5 to equal 7", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 5)).toBe(isFlaky ? 100 : 7);
-});
+  it("adds 2 + 5 to equal 7", () => {
+    expect(sum(2, 5)).toBe(7);
+  });
 
-it("adds 2 + 6 to equal 8", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 6)).toBe(isFlaky ? 100 : 8);
+  it("adds 2 + 6 to equal 8", () => {
+    expect(sum(2, 6)).toBe(8);
+  });
 });


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** Non-deterministic test logic used `Math.random()` to gate assertions, sometimes expecting `100` instead of the true sum, causing ~50% intermittent failures. Flake observed in src/math.test.ts.adds 2 + 5 to equal 7.
- **Proposed fix:** Remove randomness from tests and assert deterministic results only. Convert looped cases to a parameterized table via `it.each([[0,2,2],[1,2,3],...])`. Where randomness must be exercised, mock it deterministically with `vi.spyOn(Math, 'random').mockReturnValue(0)` and restore after each test. Skip any intentionally flaky demo expectations (like expecting `100`). Add a simple CI lint/grep guard to forbid `Math.random()` in tests.
- **Verification:** **Verification:** 10/10 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/baafd8a3-f296-447b-8918-d34ff264afce)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)