### PR TITLE
test(src): make math.test.ts deterministic; remove Math.random flakiness

### DIFF
--- a/src/math.test.ts
+++ b/src/math.test.ts
@@ -1,21 +1,18 @@
 import { expect, it } from "vitest";
 import { sum } from "./math";
 
-Array(5)
-  .fill(0)
-  .forEach((_, index) => {
-    it(`adds ${index} + 2 to equal ${index + 2}`, () => {
-      const isFlaky = Math.random() > 0.5;
-      expect(sum(index, 2)).toBe(isFlaky ? 100 : index + 2);
-    });
+const cases = [
+  { a: 0, b: 2, expected: 2 },
+  { a: 1, b: 2, expected: 3 },
+  { a: 2, b: 2, expected: 4 },
+  { a: 3, b: 2, expected: 5 },
+  { a: 4, b: 2, expected: 6 },
+  { a: 2, b: 5, expected: 7 },
+  { a: 2, b: 6, expected: 8 },
+];
+
+cases.forEach(({ a, b, expected }) => {
+  it(`sum(${a}, ${b}) === ${expected}`, () => {
+    expect(sum(a, b)).toBe(expected);
   });
-
-it("adds 2 + 5 to equal 7", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 5)).toBe(isFlaky ? 100 : 7);
-});
-
-it("adds 2 + 6 to equal 8", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 6)).toBe(isFlaky ? 100 : 8);
 });


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** Non-deterministic assertions using Math.random in src/math.test.ts caused intermittent wrong expectations, flaking src/math.test.ts.adds 2 + 5 to equal 7.
- **Proposed fix:** Remove randomness from tests and assert deterministic results only; when exercising random paths, stub Math.random via vi.spyOn(Math, 'random').mockReturnValue(0.6) and 0.4, then mockRestore(); refactor to table-driven cases; keep sum implementation unchanged.
- **Verification:** **Verification:** 10/10 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/baafd8a3-f296-447b-8918-d34ff264afce)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)