### PR TITLE
test: deflake src/math.test.ts by removing randomness

### DIFF
--- a/src/math.test.ts
+++ b/src/math.test.ts
@@ -1,21 +1,14 @@
 import { expect, it } from "vitest";
 import { sum } from "./math";
 
-Array(5)
-  .fill(0)
-  .forEach((_, index) => {
-    it(`adds ${index} + 2 to equal ${index + 2}`, () => {
-      const isFlaky = Math.random() > 0.5;
-      expect(sum(index, 2)).toBe(isFlaky ? 100 : index + 2);
-    });
-  });
-
-it("adds 2 + 5 to equal 7", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 5)).toBe(isFlaky ? 100 : 7);
-});
-
-it("adds 2 + 6 to equal 8", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 6)).toBe(isFlaky ? 100 : 8);
+it.each([
+  [0, 2, 2],
+  [1, 2, 3],
+  [2, 2, 4],
+  [3, 2, 5],
+  [4, 2, 6],
+  [2, 5, 7],
+  [2, 6, 8],
+])("adds %d + %d to equal %d", (a, b, expected) => {
+  expect(sum(a, b)).toBe(expected);
 });


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** Flakiness in src/math.test.ts.adds 2 + 5 to equal 7 (and similar looped cases) due to a nondeterministic assertion using Math.random() to sometimes expect 100; the code under test (sum) is deterministic.
- **Proposed fix:** Remove randomness from all tests in src/math.test.ts; replace Math.random()-dependent branches with deterministic expectations (e.g., `expect(sum(2, 5)).toBe(7)`), convert looped cases to `test.each`, and correct the '2 + 6' case.
- **Verification:** 10/10 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/baafd8a3-f296-447b-8918-d34ff264afce)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)