### PR TITLE
test(math): deflake by removing Math.random from expectations

### DIFF
--- a/src/math.test.ts
+++ b/src/math.test.ts
@@ -5,17 +5,14 @@ Array(5)
   .fill(0)
   .forEach((_, index) => {
     it(`adds ${index} + 2 to equal ${index + 2}`, () => {
-      const isFlaky = Math.random() > 0.5;
-      expect(sum(index, 2)).toBe(isFlaky ? 100 : index + 2);
+      expect(sum(index, 2)).toBe(index + 2);
     });
   });
 
 it("adds 2 + 5 to equal 7", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 5)).toBe(isFlaky ? 100 : 7);
+  expect(sum(2, 5)).toBe(7);
 });
 
 it("adds 2 + 6 to equal 8", () => {
-  const isFlaky = Math.random() > 0.5;
-  expect(sum(2, 6)).toBe(isFlaky ? 100 : 8);
+  expect(sum(2, 6)).toBe(8);
 });


### PR DESCRIPTION
**Chunk has come up with the following:**
- **Root cause:** Non-deterministic expectations using `Math.random()` in `src/math.test.ts` (e.g., `src/math.test.ts.adds 2 + 5 to equal 7`) sometimes asserted `100` instead of the true sum, causing flaky failures.
- **Proposed fix:** Replace all `isFlaky` branches with deterministic expectations: `expect(sum(index, 2)).toBe(index + 2);`, `expect(sum(2, 5)).toBe(7);`, `expect(sum(2, 6)).toBe(8);`.
- **Verification:** **Verification:** 10/10 verification runs passed successfully. This provides increased confidence that the root cause of flakiness has been addressed, but it is not a guarantee that the test will remain stable in all cases. Additional monitoring is advised.

[Previous CI run where test flaked](https://app.circleci.com/pipelines/workflows/baafd8a3-f296-447b-8918-d34ff264afce)



## Chunk Feedback
Want to give feedback to make these PRs better? [Click here →](mailto:ai-feedback@circleci.com)